### PR TITLE
Fix response type issues

### DIFF
--- a/__tests__/stub/fetchStub.js
+++ b/__tests__/stub/fetchStub.js
@@ -6,6 +6,7 @@ exports.setupFetchStub = () => {
         Promise.resolve({
           status: 200,
         }),
+      text: () => Promise.resolve('Sample response text'),
     };
     return Promise.resolve(fetchResponse);
   });

--- a/lib/Forge.js
+++ b/lib/Forge.js
@@ -9,7 +9,7 @@
       this._baseURL = 'https://forge.laravel.com/api/v1';
     }
 
-    async _fetchJSON(endpoint, options = {}) {
+    async _fetchJSON(endpoint, options = {}, parseResponse = true) {
       const res = await fetch(this._baseURL + endpoint, {
         ...options,
         headers: {
@@ -21,43 +21,61 @@
 
       if (!res.ok) throw new Error(res.statusText);
 
-      if (options.parseResponse !== false && res.status !== 204)
-        return res.json();
+      if (parseResponse !== false && res.status !== 204) {
+        const json = await res.json();
+        return json;
+      }
 
-      return undefined;
+      const text = await res.text();
+      return text;
     }
 
-    get(endpoint, options = {}) {
-      return this._fetchJSON(endpoint, {
-        ...options,
-        body: undefined,
-        method: 'GET',
-      });
+    get(endpoint, options = {}, parseResponse = true) {
+      return this._fetchJSON(
+        endpoint,
+        {
+          ...options,
+          body: undefined,
+          method: 'GET',
+        },
+        parseResponse,
+      );
     }
 
-    post(endpoint, body, options = {}) {
-      return this._fetchJSON(endpoint, {
-        ...options,
-        body: body ? JSON.stringify(body) : undefined,
-        method: 'POST',
-      });
+    post(endpoint, body, options = {}, parseResponse = true) {
+      return this._fetchJSON(
+        endpoint,
+        {
+          ...options,
+          body: body ? JSON.stringify(body) : undefined,
+          method: 'POST',
+        },
+        parseResponse,
+      );
     }
 
-    put(endpoint, body, options = {}) {
-      return this._fetchJSON(endpoint, {
-        ...options,
-        body: body ? JSON.stringify(body) : undefined,
-        method: 'POST',
-      });
+    put(endpoint, body, options = {}, parseResponse = true) {
+      return this._fetchJSON(
+        endpoint,
+        {
+          ...options,
+          body: body ? JSON.stringify(body) : undefined,
+          method: 'POST',
+        },
+        parseResponse,
+      );
     }
 
     patch(endpoint, operations, options = {}) {
-      return this._fetchJSON(endpoint, {
-        parseResponse: false,
+      return this._fetchJSON(
+        endpoint,
+        {
         ...options,
         body: JSON.stringify(operations),
         method: 'PATCH',
-      });
+        },
+        false,
+      );
     }
 
     delete(endpoint, options = {}) {
@@ -273,6 +291,9 @@
         activate: (serverId, siteId, certId) =>
           this.post(
             `/servers/${serverId}/sites/${siteId}/certificates/${certId}/activate`,
+            undefined,
+            {},
+            false,
           ),
         delete: (serverId, siteId, certId) =>
           this.delete(
@@ -356,7 +377,7 @@
         disable: (serverId, siteId) =>
           this.delete(`/servers/${serverId}/sites/${siteId}/deployment`),
         getScript: (serverId, siteId) =>
-          this.get(`/servers/${serverId}/sites/${siteId}/deployment/script`),
+          this.get(`/servers/${serverId}/sites/${siteId}/deployment/script`, {}, false),
         updateScript: (serverId, siteId, payload) =>
           this.put(
             `/servers/${serverId}/sites/${siteId}/deployment/script`,
@@ -389,13 +410,13 @@
     get config() {
       return {
         getNginx: (serverId, siteId) =>
-          this.get(`/servers/${serverId}/sites/${siteId}/nginx`),
+          this.get(`/servers/${serverId}/sites/${siteId}/nginx`,{}, false),
         updateNginx: (serverId, siteId, payload) =>
-          this.put(`/servers/${serverId}/sites/${siteId}/nginx`, payload),
+          this.put(`/servers/${serverId}/sites/${siteId}/nginx`, payload, {}, false),
         getEnv: (serverId, siteId) =>
-          this.get(`/servers/${serverId}/sites/${siteId}/env`),
+          this.get(`/servers/${serverId}/sites/${siteId}/env`, {}, false),
         updateEnv: (serverId, siteId, payload) =>
-          this.put(`/servers/${serverId}/sites/${siteId}/env`, payload),
+          this.put(`/servers/${serverId}/sites/${siteId}/env`, payload, {}, false),
       };
     }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rollup": "^2.30.0"
   },
   "dependencies": {
-    "cross-fetch": "^3.0.6"
+    "cross-fetch": "^3.1.5"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/src/Forge.js
+++ b/src/Forge.js
@@ -204,7 +204,9 @@ class Forge extends ForgeRequest {
       activate: (serverId, siteId, certId) =>
         this.post(
           `/servers/${serverId}/sites/${siteId}/certificates/${certId}/activate`,
-          {parseResponse: false},
+          undefined,
+          {},
+          false,
         ),
       delete: (serverId, siteId, certId) =>
         this.delete(
@@ -288,7 +290,7 @@ class Forge extends ForgeRequest {
       disable: (serverId, siteId) =>
         this.delete(`/servers/${serverId}/sites/${siteId}/deployment`),
       getScript: (serverId, siteId) =>
-        this.get(`/servers/${serverId}/sites/${siteId}/deployment/script`, {parseResponse: false}),
+        this.get(`/servers/${serverId}/sites/${siteId}/deployment/script`, {}, false),
       updateScript: (serverId, siteId, payload) =>
         this.put(
           `/servers/${serverId}/sites/${siteId}/deployment/script`,
@@ -321,13 +323,13 @@ class Forge extends ForgeRequest {
   get config() {
     return {
       getNginx: (serverId, siteId) =>
-        this.get(`/servers/${serverId}/sites/${siteId}/nginx`, {parseResponse: false}),
+        this.get(`/servers/${serverId}/sites/${siteId}/nginx`,{}, false),
       updateNginx: (serverId, siteId, payload) =>
-        this.put(`/servers/${serverId}/sites/${siteId}/nginx`, payload, {parseResponse: false}),
+        this.put(`/servers/${serverId}/sites/${siteId}/nginx`, payload, {}, false),
       getEnv: (serverId, siteId) =>
-        this.get(`/servers/${serverId}/sites/${siteId}/env`, {parseResponse: false}),
+        this.get(`/servers/${serverId}/sites/${siteId}/env`, {}, false),
       updateEnv: (serverId, siteId, payload) =>
-        this.put(`/servers/${serverId}/sites/${siteId}/env`, payload, {parseResponse: false}),
+        this.put(`/servers/${serverId}/sites/${siteId}/env`, payload, {}, false),
     };
   }
 

--- a/src/Forge.js
+++ b/src/Forge.js
@@ -204,6 +204,7 @@ class Forge extends ForgeRequest {
       activate: (serverId, siteId, certId) =>
         this.post(
           `/servers/${serverId}/sites/${siteId}/certificates/${certId}/activate`,
+          {parseResponse: false},
         ),
       delete: (serverId, siteId, certId) =>
         this.delete(
@@ -287,7 +288,7 @@ class Forge extends ForgeRequest {
       disable: (serverId, siteId) =>
         this.delete(`/servers/${serverId}/sites/${siteId}/deployment`),
       getScript: (serverId, siteId) =>
-        this.get(`/servers/${serverId}/sites/${siteId}/deployment/script`),
+        this.get(`/servers/${serverId}/sites/${siteId}/deployment/script`, {parseResponse: false}),
       updateScript: (serverId, siteId, payload) =>
         this.put(
           `/servers/${serverId}/sites/${siteId}/deployment/script`,
@@ -320,13 +321,13 @@ class Forge extends ForgeRequest {
   get config() {
     return {
       getNginx: (serverId, siteId) =>
-        this.get(`/servers/${serverId}/sites/${siteId}/nginx`),
+        this.get(`/servers/${serverId}/sites/${siteId}/nginx`, {parseResponse: false}),
       updateNginx: (serverId, siteId, payload) =>
-        this.put(`/servers/${serverId}/sites/${siteId}/nginx`, payload),
+        this.put(`/servers/${serverId}/sites/${siteId}/nginx`, payload, {parseResponse: false}),
       getEnv: (serverId, siteId) =>
-        this.get(`/servers/${serverId}/sites/${siteId}/env`),
+        this.get(`/servers/${serverId}/sites/${siteId}/env`, {parseResponse: false}),
       updateEnv: (serverId, siteId, payload) =>
-        this.put(`/servers/${serverId}/sites/${siteId}/env`, payload),
+        this.put(`/servers/${serverId}/sites/${siteId}/env`, payload, {parseResponse: false}),
     };
   }
 

--- a/src/core/ForgeRequest.js
+++ b/src/core/ForgeRequest.js
@@ -6,7 +6,7 @@ class ForgeRequest {
     this._baseURL = 'https://forge.laravel.com/api/v1';
   }
 
-  async _fetchJSON(endpoint, options = {}) {
+  async _fetchJSON(endpoint, options = {}, parseResponse = true) {
     const res = await fetch(this._baseURL + endpoint, {
       ...options,
       headers: {
@@ -18,43 +18,61 @@ class ForgeRequest {
 
     if (!res.ok) throw new Error(res.statusText);
 
-    if (options.parseResponse !== false && res.status !== 204)
-      return res.json();
+    if (parseResponse !== false && res.status !== 204) {
+      const json = await res.json();
+      return json;
+    }
 
-    return res.text();
+    const text = await res.text();
+    return text;
   }
 
-  get(endpoint, options = {}) {
-    return this._fetchJSON(endpoint, {
-      ...options,
-      body: undefined,
-      method: 'GET',
-    });
+  get(endpoint, options = {}, parseResponse = true) {
+    return this._fetchJSON(
+      endpoint,
+      {
+        ...options,
+        body: undefined,
+        method: 'GET',
+      },
+      parseResponse,
+    );
   }
 
-  post(endpoint, body, options = {}) {
-    return this._fetchJSON(endpoint, {
-      ...options,
-      body: body ? JSON.stringify(body) : undefined,
-      method: 'POST',
-    });
+  post(endpoint, body, options = {}, parseResponse = true) {
+    return this._fetchJSON(
+      endpoint,
+      {
+        ...options,
+        body: body ? JSON.stringify(body) : undefined,
+        method: 'POST',
+      },
+      parseResponse,
+    );
   }
 
-  put(endpoint, body, options = {}) {
-    return this._fetchJSON(endpoint, {
-      ...options,
-      body: body ? JSON.stringify(body) : undefined,
-      method: 'POST',
-    });
+  put(endpoint, body, options = {}, parseResponse = true) {
+    return this._fetchJSON(
+      endpoint,
+      {
+        ...options,
+        body: body ? JSON.stringify(body) : undefined,
+        method: 'POST',
+      },
+      parseResponse,
+    );
   }
 
   patch(endpoint, operations, options = {}) {
-    return this._fetchJSON(endpoint, {
-      parseResponse: false,
+    return this._fetchJSON(
+      endpoint,
+      {
       ...options,
       body: JSON.stringify(operations),
       method: 'PATCH',
-    });
+      },
+      false,
+    );
   }
 
   delete(endpoint, options = {}) {

--- a/src/core/ForgeRequest.js
+++ b/src/core/ForgeRequest.js
@@ -21,7 +21,7 @@ class ForgeRequest {
     if (options.parseResponse !== false && res.status !== 204)
       return res.json();
 
-    return undefined;
+    return res.text();
   }
 
   get(endpoint, options = {}) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,7 +1824,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-fetch@^3.0.6:
+cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==


### PR DESCRIPTION
Some endpoints respond with only a string instead of JSON. This commit skips parsing those responses and returns the response text as a string.